### PR TITLE
remove BOM from shortcode param

### DIFF
--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -28,6 +28,7 @@ class ShortcodableController extends Controller{
 		$classname = false;
 		$shortcodeData = false;
 		if($shortcode = $this->request->requestVar('Shortcode')){
+			$shortcode = str_replace("\xEF\xBB\xBF", '', $shortcode); //remove BOM inside string on cursor position...
 			$shortcodeData = singleton('ShortcodableParser')->the_shortcodes(array(), $shortcode);
 			if(isset($shortcodeData[0])){
 				$shortcodeData = $shortcodeData[0]; 


### PR DESCRIPTION
somehow the javascript interprets the current cursor position as BOM, which you cannot see or hear but it confuses php, e.g. placing the cursor on a param name the returned form has a empty field. Debugging this drove me partially crazy but with help in IRC i got it managed. Thanks @Zauberfish for giving the right hints.

A probably nicer solution would be to strip the BOM out in javascript before sending to the controller...
