### PR TITLE
Add route to ShortcodeableController

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,6 @@ LeftAndMain:
     - 'shortcodable/javascript/shortcodable.js'
   extra_requirements_css:
     - 'shortcodable/css/shortcodable.css'
+Director:
+  rules:
+    ShortcodableController: ShortcodableController


### PR DESCRIPTION
Routes to controllers now need to be explicitly defined: https://docs.silverstripe.org/en/3.2/changelogs/3.2.0/#api-removed-url-routing-by-controller-name