### PR TITLE
Add option to display shortcode visual placeholder

### DIFF
--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -11,6 +11,7 @@ class ShortcodableController extends Controller
      */
     private static $allowed_actions = array(
         'ShortcodeForm',
+        'shortcodePlaceHolder',
     );
 
     /**
@@ -88,6 +89,11 @@ class ShortcodableController extends Controller
                         $fields->push(CompositeField::create($attrFields)->addExtraClass('attributes-composite'));
                     }
                 }
+                if (singleton($classname)->hasMethod('getShortcodePlaceHolder')) {
+                    $fields->push(CompositeField::create(array(
+                        HiddenField::create('HasPlaceholder', '', 1)
+                    ))->addExtraClass('attributes-composite'));
+                }
             }
         }
 
@@ -111,5 +117,22 @@ class ShortcodableController extends Controller
         $this->extend('updateShortcodeForm', $form);
 
         return $form;
+    }
+
+    /**
+     * Generates shortcode placeholder to display inside TinyMCE instead of the shortcode.
+     *
+     * @return void
+     */
+    public function shortcodePlaceHolder()
+    {
+        if (!Permission::check('CMS_ACCESS_CMSMain')) {
+            return;
+        }
+
+        $classname = $this->request->param('OtherID');
+        if (singleton($classname)->hasMethod('getShortcodePlaceHolder')) {
+            return singleton($classname)->getShortcodePlaceHolder();
+        }
     }
 }

--- a/javascript/editor_plugin.js
+++ b/javascript/editor_plugin.js
@@ -1,26 +1,93 @@
-(function() {
+(function () {
     if (typeof tinymce !== 'undefined') {
-    	tinymce.create('tinymce.plugins.shortcodable', {
-    		getInfo : function() {
-    			return {
-    				longname : 'Shortcodable - Shortcode UI plugin for SilverStripe',
-    				author : 'Shea Dawson',
-    				authorurl : 'http://www.livesource.co.nz/',
-    				infourl : 'http://www.livesource.co.nz/',
-    				version : "1.0"
-    			};
-    		},
+        // Replace placeholder image with the shortcode.
+        function getAttribute(string, attr) {
+            attr = new RegExp(attr + '=\"([^\"]+)\"', 'g').exec(string);
+            return attr ? tinymce.DOM.decode(attr[1]) : '';
+        }
 
-    		init : function(ed, url) {
-    			ed.addButton('shortcodable', {title : 'Insert Shortcode', cmd : 'shortcodable', 'class' : 'mce_shortcode'});
+        tinymce.create('tinymce.plugins.shortcodable', {
+            getInfo: function () {
+                return {
+                    longname: 'Shortcodable - Shortcode UI plugin for SilverStripe',
+                    author: 'Shea Dawson',
+                    authorurl: 'http://www.livesource.co.nz/',
+                    infourl: 'http://www.livesource.co.nz/',
+                    version: "1.0"
+                };
+            },
 
-    			ed.addCommand('shortcodable', function(ed) {
-    				jQuery('#' + this.id).entwine('ss').openShortcodeDialog();
-    			});
-    		}
-    	});
+            init: function (ed, url) {
+                var me = this;
+                ed.addButton('shortcodable', {
+                    title: 'Insert Shortcode',
+                    cmd: 'shortcodable',
+                    'class': 'mce_shortcode'
+                });
 
-    	// Adds the plugin class to the list of available TinyMCE plugins
-    	tinymce.PluginManager.add("shortcodable", tinymce.plugins.shortcodable);
+                ed.addCommand('shortcodable', function (ed) {
+                    jQuery('#' + this.id).entwine('ss').openShortcodeDialog();
+                });
+
+                // On load replace shorcode with placeholder.
+                ed.onBeforeSetContent.add(function (ed, o) {
+                    o.content = me._showPlaceholder(o.content);
+                });
+
+                // On insert replace shortcode with placeholder.
+                ed.onExecCommand.add(function (ed, cmd, ui, val) {
+                    if (cmd === 'mceInsertContent') {
+                        ed.setContent(me._showPlaceholder(ed.getContent()));
+                    }
+                });
+
+                // On save replace placeholder with shortcode.
+                ed.onPostProcess.add(function (e, o) {
+                    o.content = me._getShortcode(o.content);
+                });
+
+                ed.onDblClick.add(function (ed, e) {
+                    var dom = ed.dom, node = e.target;
+                    if (node.nodeName === 'IMG' && dom.hasClass(node, 'shortcode-placeholder') && e.button !== 2) {
+                        ed.execCommand('shortcodable');
+                    }
+                });
+            },
+            // Replace shortcode with a placeholder.
+            _showPlaceholder: function (co) {
+                return co.replace(/\[([a-z]+)\s+([^\]]*)\]/gi, function (found, name, params) {
+                    var id = getAttribute(params, 'id');
+                    var hasPlaceholder = getAttribute(params, 'HasPlaceholder');
+                    if (hasPlaceholder == 1) {
+                        var img = jQuery('<img/>')
+                            .attr('class', 'shortcode-placeholder mceItem')
+                            .attr('title', name + ' ' + params)
+                            .attr('src', 'ShortcodableController/shortcodePlaceHolder/' + id + '/' + name);
+                        return img.prop('outerHTML');
+                    }
+
+                    return found;
+                });
+            },
+            // Get the shortcode from the placeholder.
+            _getShortcode: function (co) {
+                var content = jQuery(co);
+                content.find('.shortcode-placeholder').each(function () {
+                    var el = jQuery(this);
+                    var shortCode = '[' + tinymce.trim(el.attr('title')) + ']';
+                    el.replaceWith(shortCode);
+                });
+                var originalContent = '';
+                content.each(function () {
+                    if (this.outerHTML !== undefined) {
+                        originalContent += this.outerHTML;
+                    }
+                });
+                return originalContent;
+            }
+        });
+
+        // Adds the plugin class to the list of available TinyMCE plugins
+        tinymce.PluginManager.add("shortcodable", tinymce.plugins.shortcodable);
     }
 })();

--- a/javascript/shortcodable.js
+++ b/javascript/shortcodable.js
@@ -113,7 +113,11 @@
 				this.reloadForm('shortcode', shortcode)
 			},
 			getCurrentShortcode: function() {
-				return $(this.getSelection()).text();
+				var selection = $(this.getSelection()), selectionText = selection.text();
+				if (selection.attr('title') !== undefined) {
+					return '[' + selection.attr('title') + ']';
+				}
+				return selectionText;
 			}
 		});
 	});


### PR DESCRIPTION
Issue #9 

With this change the Shortcodable class have the option to implement the method `getShortcodePlaceHolder`. This method must output an image that will be used instead of the shortcode text. This method is optional, if it does not exists the functionality fallback to plain text.

The properties of the shortcode are stored in the title attribute of the image displayed in TinyMCE. So they are visible to user on hover.

Double click the placeholder image will fire the edit event same as highlighting the shortcode text.

Example:
```
class ImageGallery extends DataObject
{
    ...
    public function getShortcodePlaceHolder()
    {
        // Path to font file & size
        $fontFile = Director::baseFolder() . '/' . $this->ThemeDir() . '/fonts/FiraSans-Medium.ttf';
        $fontSize = 12;

        // Shortcode id value
        $text = Controller::curr()->getRequest()->param('ID');

        // Create an image with the shortcode id in center
        $imageBox = imagettfbbox($fontSize, 0, $fontFile, $text);

        $width = abs($imageBox[4] - $imageBox[0]) + 10;
        $height = abs($imageBox[5] - $imageBox[1]) + 10;

        $image = imagecreatetruecolor($width, $height);

        $color = imagecolorallocate($image, 1, 0, 0);
        $backgroundColor = imagecolorallocate($image, 200, 200, 200);

        imagefill($image, 0, 0, $backgroundColor);

        // Padding of 5 pixels.
        $x = 5;
        $y = $height - 5;
        imagettftext($image, $fontSize, 0, $x, $y, $color, $fontFile, $text);

        // Generate and send image to browser:
        header('Content-type: image/png');
        imagepng($image);
        imagedestroy($image);

        die;
    }

```