### PR TITLE
Enable customised name and keyword for shortcodes instead of class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ class ImageGallery extends DataObject
 
 Create the ImageGallery.ss template then that's it, done!
 
+### Custom shortcode names
+
+You can specify a name that will appear in the modal dropdown when inserting shortcode through TinyMCE.
+Following code would e.g. change the name from *CustomSectionsContentBlock* to *Content block with custom sections*.
+
+```php
+public function getShortcodeNiceName()
+{
+    return 'Content block with custom sections';
+}
+```
+
+You can as well change the actual shortcode (keyword) that will appear in the wysiwyg editor.
+Stick this function into your shortcodable dataobject and the output will look like *[Sections_ContentBlock id=""]*
+
+```php
+public function getShortcodeKeyword()
+{
+    return 'Sections_ContentBlock';
+}
+```
+
+**TODO**: Enable changing this via config YAML files.
+
 ## Restricting data object selection
 
 If you would like to customise or filter the list of available shortcodable DataObject records available in the dropdown, you can supply a custom getShortcodableRecords method on your shortcodable DataObject. The method should return an associative array suitable for the DropdownField. For example:

--- a/code/Shortcodable.php
+++ b/code/Shortcodable.php
@@ -24,8 +24,12 @@ class Shortcodable extends Object
             if (!singleton($class)->hasMethod('parse_shortcode')) {
                 user_error("Failed to register \"$class\" with shortcodable. $class must have the method parse_shortcode(). See /shortcodable/README.md", E_USER_ERROR);
             }
-            ShortcodeParser::get('default')->register($class, array($class, 'parse_shortcode'));
-            singleton('ShortcodableParser')->register($class);
+            $kw = $class;
+            if (singleton($class)->hasMethod('getShortcodeKeyword')) {
+                $kw = singleton($class)->getShortcodeKeyword();
+            }
+            ShortcodeParser::get('default')->register($kw, array($class, 'parse_shortcode'));
+            singleton('ShortcodableParser')->register($kw);
         }
     }
 

--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -30,7 +30,7 @@ class ShortcodableController extends Controller
         $classList = ShortCodable::get_shortcodable_classes();
         $classes = array();
         foreach ($classList as $class) {
-            $classes[$class] = singleton($class)->hasMethod('singular_name') ? singleton($class)->singular_name() : $class;
+            $classes[$class] = singleton($class)->hasMethod('getShortcodeNiceName') ? singleton($class)->getShortcodeNiceName() : (singleton($class)->hasMethod('singular_name') ? singleton($class)->singular_name() : $class);
         }
 
         // load from the currently selected ShortcodeType or Shortcode data
@@ -62,8 +62,8 @@ class ShortcodableController extends Controller
                 )
             )->addExtraClass('CompositeField composite cms-content-header nolabel'),
             LiteralField::create('shortcodablefields', '<div class="ss-shortcodable content">'),
-            DropdownField::create('ShortcodeType', 'ShortcodeType', $classes, $classname)
-                ->setHasEmptyDefault(true)
+            DropdownField::create('ShortcodeType', 'Shortcode type', $classes, $classname)
+                ->setHasEmptyDefault(true)->setEmptyString('--- select one ---')
                 ->addExtraClass('shortcode-type'),
 
         ));
@@ -80,7 +80,7 @@ class ShortcodableController extends Controller
                     }
                     $fields->push(
                         DropdownField::create('id', $class->singular_name(), $dataObjectSource)
-                            ->setHasEmptyDefault(true)
+                            ->setHasEmptyDefault(true)->setEmptyString('--- select one ---')
                     );
                 }
                 if (singleton($classname)->hasMethod('getShortcodeFields')) {
@@ -88,6 +88,11 @@ class ShortcodableController extends Controller
                         $fields->push(CompositeField::create($attrFields)->addExtraClass('attributes-composite'));
                     }
                 }
+                $kw = $classname;
+                if (singleton($classname)->hasMethod('getShortcodeKeyword')) {
+                    $kw = singleton($classname)->getShortcodeKeyword();
+                }
+                $fields->push(HiddenField::create('ShortcodeKeyword', '', $kw));
             }
         }
 

--- a/javascript/shortcodable.js
+++ b/javascript/shortcodable.js
@@ -59,7 +59,7 @@
 			// get the html to insert
 			getHTML: function(){
 				var data = this.getAttributes();
-				var html = data.shortcodeType;
+				var html = data.shortcodeKeyword;
 
 				for (var key in data.attributes) {
 				    html += ' ' + key + '="' + data.attributes[key] + '"';
@@ -71,6 +71,7 @@
 			// get shortcode attributes from shortcode form
 			getAttributes: function() {
 				var attributes = {};
+                var shortcodeKeyword = this.find(':input[name=ShortcodeKeyword]').val();
 				var shortcodeType = this.find(':input[name=ShortcodeType]').val();
 				var id = this.find(':input[name=id]').val();
 				if (id) {
@@ -91,7 +92,8 @@
 				}
 
 				return {
-					'shortcodeType' : this.find(':input[name=ShortcodeType]').val(),
+					'shortcodeType' : shortcodeType,
+                    'shortcodeKeyword' : shortcodeKeyword,
 					'attributes' : attributes
 				};
 			},


### PR DESCRIPTION
Issue #10 

This change adds an option to assign more descriptive name than the classname (appears in the modal dropdown) as well as select a keyword placeholder for the wysiwyg editor.

