### PR TITLE
Unable to register classes with extensions

### DIFF
--- a/code/Shortcodable.php
+++ b/code/Shortcodable.php
@@ -24,7 +24,7 @@ class Shortcodable extends Object
             if (!singleton($class)->hasMethod('parse_shortcode')) {
                 user_error("Failed to register \"$class\" with shortcodable. $class must have the method parse_shortcode(). See /shortcodable/README.md", E_USER_ERROR);
             }
-            ShortcodeParser::get('default')->register($class, array($class, 'parse_shortcode'));
+            ShortcodeParser::get('default')->register(singleton($class), array($class, 'parse_shortcode'));
             singleton('ShortcodableParser')->register($class);
         }
     }


### PR DESCRIPTION
ShortcodeParser->register() checks to see if the supplied method is_callable.  However, if the classname is provided as a string instead of an instance, extensions will not be applied.  Setting the object param as a singleton of the class solves this problem.

To test:
1. Create and apply an extension to Member with parse_shortcode() implemented (can just return a string, no need for a template)
2. Add Member as a shortcodable_class to Shortcodable in config.yml
3. flush
4. Attempt to insert the shortcode in a page.  The code will be inserted properly, but remain unparsed and ugly.