### PR TITLE
Extended translation support

### DIFF
--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -134,7 +134,7 @@ class ShortcodableController extends LeftAndMain
                 )
             )->addExtraClass('CompositeField composite cms-content-header nolabel'),
             LiteralField::create('shortcodablefields', '<div class="ss-shortcodable content">'),
-            DropdownField::create('ShortcodeType', 'ShortcodeType', $classes, $classname)
+            DropdownField::create('ShortcodeType', _t('Shortcodable.SHORTCODETYPE', 'Shortcode type'), $classes, $classname)
                 ->setHasEmptyDefault(true)
                 ->addExtraClass('shortcode-type')
         ));


### PR DESCRIPTION
Added translation support for ShortcodeType dropdown. Allows for a translated label next to the dropdown field in the Shortcodable TinyMCE pop-up.