### PR TITLE
fixed issue - shortcodes editor usage if logged member isn't ADMIN role

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,7 +7,7 @@ LeftAndMain:
 
 Director:
   rules:
-    ShortcodableController: ShortcodableController
+    'admin/shortcodes': ShortcodableController
 
 Shortcodable:
   htmleditor_names:

--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -6,19 +6,17 @@
  **/
 class ShortcodableController extends LeftAndMain
 {
-    /**
-     * @var string
-     */
-    const URLSegment = 'ShortcodableController';
+    private static $url_segment = 'shortcodes';
+    private static $menu_title = 'Shortcodes';
+    private static $required_permission_codes = 'CMS_ACCESS_AssetAdmin';
 
     /**
      * @var array
      */
     private static $allowed_actions = array(
-        'ShortcodeForm' => 'ADMIN',
-        'index' => 'ADMIN',
-        'handleEdit' => 'ADMIN',
-        'shortcodePlaceHolder' => 'ADMIN'
+        'ShortcodeForm' => 'CMS_ACCESS_AssetAdmin',
+        'handleEdit' => 'CMS_ACCESS_AssetAdmin',
+        'shortcodePlaceHolder' => 'CMS_ACCESS_AssetAdmin'
     );
 
     /**
@@ -47,7 +45,7 @@ class ShortcodableController extends LeftAndMain
      * Get the shortcodable class by whatever means possible.
      * Determine if this is a new shortcode, or editing an existing one.
      */
-    function init()
+    public function init()
     {
         parent::init();
         if ($data = $this->getShortcodeData()) {
@@ -67,12 +65,14 @@ class ShortcodableController extends LeftAndMain
     {
         if ($this->shortcodableclass) {
             return Controller::join_links(
-                self::URLSegment,
+                $this->config()->url_base,
+                $this->config()->url_segment,
                 'edit',
                 $this->shortcodableclass
             );
         }
-        return Controller::join_links(self::URLSegment, $action);
+
+        return Controller::join_links($this->config()->url_base, $this->config()->url_segment, $action);
     }
 
     /**
@@ -90,15 +90,15 @@ class ShortcodableController extends LeftAndMain
      */
     protected function getShortcodeData()
     {
-        if($this->shortcodedata){
+        if ($this->shortcodedata) {
             return $this->shortcodedata;
         }
         $data = false;
-        if($shortcode = $this->request->requestVar('Shortcode')){
+        if ($shortcode = $this->request->requestVar('Shortcode')) {
             //remove BOM inside string on cursor position...
             $shortcode = str_replace("\xEF\xBB\xBF", '', $shortcode);
             $data = singleton('ShortcodableParser')->the_shortcodes(array(), $shortcode);
-            if(isset($data[0])){
+            if (isset($data[0])) {
                 $this->shortcodedata = $data[0];
                 return $this->shortcodedata;
             }
@@ -119,7 +119,7 @@ class ShortcodableController extends LeftAndMain
         if ($this->isnew) {
             $headingText = _t('Shortcodable.EDITSHORTCODE', 'Edit Shortcode');
         } else {
-            $headingText =  sprintf(
+            $headingText = sprintf(
                 _t('Shortcodable.EDITSHORTCODE', 'Edit %s Shortcode'),
                 singleton($this->shortcodableclass)->singular_name()
             );
@@ -169,7 +169,7 @@ class ShortcodableController extends LeftAndMain
             FormAction::create('insert', _t('Shortcodable.BUTTONINSERTSHORTCODE', 'Insert shortcode'))
                 ->addExtraClass('ss-ui-action-constructive')
                 ->setAttribute('data-icon', 'accept')
-                ->setUseButtonTag(true),
+                ->setUseButtonTag(true)
         ));
 
         // form

--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -8,15 +8,15 @@ class ShortcodableController extends LeftAndMain
 {
     private static $url_segment = 'shortcodes';
     private static $menu_title = 'Shortcodes';
-    private static $required_permission_codes = 'CMS_ACCESS_AssetAdmin';
+    private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
     /**
      * @var array
      */
     private static $allowed_actions = array(
-        'ShortcodeForm' => 'CMS_ACCESS_AssetAdmin',
-        'handleEdit' => 'CMS_ACCESS_AssetAdmin',
-        'shortcodePlaceHolder' => 'CMS_ACCESS_AssetAdmin'
+        'ShortcodeForm' => 'CMS_ACCESS_CMSMain',
+        'handleEdit' => 'CMS_ACCESS_CMSMain',
+        'shortcodePlaceHolder' => 'CMS_ACCESS_CMSMain'
     );
 
     /**

--- a/javascript/editor_plugin.js
+++ b/javascript/editor_plugin.js
@@ -48,7 +48,7 @@
                     return content.replace(/\[([a-z]+)\s*([^\]]*)\]/gi, function (found, name, params) {
                         var id = plugin.getAttribute(params, 'id');
                         if (placeholderClasses.indexOf(name) != -1) {
-                            var src = encodeURI('ShortcodableController/shortcodePlaceHolder/' + name + '/' + id + '?Shortcode=[' + name + ' ' + params + ']');
+                            var src = encodeURI('admin/shortcodes/shortcodePlaceHolder/' + name + '/' + id + '?Shortcode=[' + name + ' ' + params + ']');
                             var img = jQuery('<img/>')
                                 .attr('class', 'shortcode-placeholder mceItem')
                                 .attr('title', name + ' ' + params)

--- a/javascript/shortcodable.js
+++ b/javascript/shortcodable.js
@@ -11,7 +11,7 @@
         // add shortcode controller url to cms-editor-dialogs
         $('#cms-editor-dialogs').entwine({
             onmatch: function(){
-                this.attr('data-url-shortcodeform', 'ShortcodableController/ShortcodeForm/forTemplate');
+                this.attr('data-url-shortcodeform', 'admin/shortcodes/ShortcodeForm/forTemplate');
             }
         });
 


### PR DESCRIPTION
- shortcode controller permissions granted for everybody who can access CMS, used private static $required_permission_codes
- psr-2 formatting
- const URLSegment replaced with standard private static $url_segment
- fixed Link function, using $url_base
- fixed controller paths in js
