### PR TITLE
Add setting to remove div container on block elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ composer require sheadawson/silverstripe-shortcodable
 See [this gist](https://gist.github.com/sheadawson/12c5e5a2b42272bd90f703941450d677) for a well documented example of a Shortcodable ImageGallery to get you started. This example is for a subclass of DataObject. If your shortcodable object doesn't need it's own database record, you can use the same example but use ViewableData as the parent class.
 
 #### TinyMCE block elements
-In SilverStripe 3 shortcodes tend to get wrapped in paragraph elements, which is a problem if your shortcode will be rendered as a block element. To get around this you can flag shortcodable classes as block elements with a config setting.
+In SilverStripe 3 shortcodes tend to get wrapped in paragraph elements, which is a problem if your shortcode will be rendered as a block element. To get around this you can flag shortcodable classes as block elements with a config setting. If you don't want to replace the paragraph tag with a div this can be disabled as well.
 
 ```yml
 MyShortcodableClass:
   shortcodable_is_block: true
+  disable_wrapper: true
 ```
 
 ## CMS Usage

--- a/code/extensions/ShortcodableShortcodeParserExtension.php
+++ b/code/extensions/ShortcodableShortcodeParserExtension.php
@@ -13,10 +13,15 @@ class ShortcodableShortcodeParserExtension extends Extension
                 $shortcodeName = $matches[3];
                 // Since we're only concerned with shortcodable objects we know the
                 // shortcode name will be the class name so don't have to look it up
-                return ($shortcodeName && $parser->registered($shortcodeName)
-                    && Config::inst()->get($shortcodeName, 'shortcodable_is_block'))
-                    ? "<div$matches[1]>[$matches[2]]</div>"
-                    : $matches[0];
+                if ($shortcodeName && $parser->registered($shortcodeName)) {
+                    if (Config::inst()->get($shortcodeName, 'shortcodable_is_block') && Config::inst()->get($shortcodeName, 'disable_wrapper')) {
+                        return "[$matches[2]]";  
+                    }
+                    if (Config::inst()->get($shortcodeName, 'shortcodable_is_block')) {
+                        return "<div$matches[1]>[$matches[2]]</div>";  
+                    }
+                }
+                return $matches[0];
             },
             $content
         );


### PR DESCRIPTION
I often include a wrapper div of my own in my template includes so needed a way to get rid of the inserted one.