### PR TITLE
Fix for `onbeforesubmitform` when plugin disabled

### DIFF
--- a/javascript/shortcodable.js
+++ b/javascript/shortcodable.js
@@ -32,9 +32,11 @@
             'from .cms-edit-form': {
                 onbeforesubmitform: function(e) {
                     var shortcodable = tinyMCE.activeEditor.plugins.shortcodable;
-                    var ed = this.getEditor();
-                    var newContent = shortcodable.replacePlaceholdersWithShortcodes($(this).val(), ed);
-                    $(this).val(newContent);
+                    if (shortcodable) {
+                        var ed = this.getEditor();
+                        var newContent = shortcodable.replacePlaceholdersWithShortcodes($(this).val(), ed);
+                        $(this).val(newContent);
+                    }
                 }
             },
         });


### PR DESCRIPTION
Currently `onbeforesubmitform` will try and run the `shortcodable` TinyMCE plugin even if it's not registered. So this is a simple fix to stop that from happening and allow compatibility with multiple `HtmlEditorConfig`'s.