### PR TITLE
FIX (before submit): save html content to textarea before shortcode change

### DIFF
--- a/javascript/shortcodable.js
+++ b/javascript/shortcodable.js
@@ -31,6 +31,12 @@
              */
             'from .cms-edit-form': {
                 onbeforesubmitform: function(e) {
+                    // Save the updated content here, rather than _after_ replacing the placeholders
+                    // otherwise you're replacing the shortcode html with the shortcode, then writing
+                    // the html back to the textarea value, overriding what the shortcode conversion
+                    // process has done
+                    this._super(e);
+                    
                     var shortcodable = tinyMCE.activeEditor.plugins.shortcodable;
                     if (shortcodable) {
                         var ed = this.getEditor();


### PR DESCRIPTION
Save the updated content from the html editor to the underlying text area before the shortcode's html is replaced with the actual shortcode. This way the shortcode tag will be in the database instead of the html tag.

The fix in https://github.com/sheadawson/silverstripe-shortcodable/commit/165ce3b013aef1db6f0dea0ba08b97e7e81428f0 was 99% of the way there, just the wrong way around

This should fix https://github.com/sheadawson/silverstripe-shortcodable/issues/45 as well as https://github.com/sheadawson/silverstripe-shortcodable/issues/49 for 3.0. I'll pull request the fix for master as well.