### PR TITLE
Check if DataObject before calling ORM/::get() on class

### DIFF
--- a/src/Controller/ShortcodableController.php
+++ b/src/Controller/ShortcodableController.php
@@ -229,7 +229,7 @@ class ShortcodableController extends LeftAndMain
             return;
         }
 
-        if ($id) {
+        if ($id && is_subclass_of($classname, 'DataObject')) {
             $object = $classname::get()->byID($id);
         } else {
             $object = singleton($classname);


### PR DESCRIPTION
A shortcode may have an id attribute without necessarily representing a database record, so we should check first. 
(NOTE BEFORE MERGING: SS4 may require checking for 'SilverStripe\ORM\DataObject' instead?)