### PR TITLE
Check if DataObject before calling ORM/::get() on class

### DIFF
--- a/code/controllers/ShortcodableController.php
+++ b/code/controllers/ShortcodableController.php
@@ -213,7 +213,7 @@ class ShortcodableController extends LeftAndMain
             return;
         }
 
-        if ($id) {
+        if ($id && is_subclass_of($classname, 'DataObject')) {
             $object = $classname::get()->byID($id);
         } else {
             $object = singleton($classname);


### PR DESCRIPTION
A shortcode may have an id attribute without necessarily representing a database record, so check first.