### PR TITLE
Fix bug with '=' present in shortcode attribute value

### DIFF
--- a/src/Extensions/ShortcodableParser.php
+++ b/src/Extensions/ShortcodableParser.php
@@ -43,7 +43,7 @@ class ShortcodableParser extends Object
      */
     public function parse_atts($content)
     {
-        $content = preg_match_all('/([^ ]*)=(\'([^\']*)\'|\"([^\"]*)\"|([^ ]*))/', trim($content), $c);
+        $content = preg_match_all('/([^ =]*)=(\'([^\']*)\'|\"([^\"]*)\"|([^ ]*))/', trim($content), $c);
         list($dummy, $keys, $values) = array_values($c);
         $c = array();
         foreach ($keys as $key => $value) {


### PR DESCRIPTION
Eg [sc url="[https://www.youtube.com/watch?v=dQw4w9WgXcQ]()"]
Would be parsed into (attrs):
array('url=https://www.youtube.com/watch?v' => 'dQw4w9WgXcQ')