### PR TITLE
Make wrappable shortcodes

### DIFF
--- a/javascript/shortcodable.js
+++ b/javascript/shortcodable.js
@@ -81,19 +81,33 @@
             },
             // get the html to insert
             getHTML: function(){
-                var data = this.getAttributes();
-                var html = data.shortcodeType;
+
+				var data = this.getAttributes();
+				var html = data.shortcodeType;
+                var content = data.attributes['Content'];
+                var shortcode;
 
                 for (var key in data.attributes) {
-                    html += ' ' + key + '="' + data.attributes[key] + '"';
+                    if(key != 'Content') {
+                        html += ' ' + key + '="' + data.attributes[key] + '"';
+                    }
                 }
 
                 if (html.length) {
-                    return "[" + html + "]";
-                } else {
+
+                    if(content) {
+        				shortcode = "[" + html + "]" + data.attributes['Content'] + "[/" + data.shortcodeType + "]";
+                    }else {
+                        shortcode = "[" + html + "]";
+                    }
+
+                    return shortcode;
+
+                }else {
                     return '';
                 }
-            },
+
+			},
             // get shortcode attributes from shortcode form
             getAttributes: function() {
                 var attributes = {};


### PR DESCRIPTION
This might not be the most elegant way to achieve this, but I needed to be able to populate the content for the shortcode from the popup. Creating a field named "Content" adds shortcode content and appends a closing tag.

Example of adding field:

````
	public function getShortcodeFields() {

		return FieldList::create(
			TextField::create('Content', 'Content')
		);

	}
```
#2 