### PR TITLE
Workaround until TinyMCE placeholders are fixed

### DIFF
--- a/javascript/editor_plugin.js
+++ b/javascript/editor_plugin.js
@@ -13,8 +13,6 @@
             },
 
             init: function (ed, url) {
-                var me = tinyMCE.activeEditor.plugins.shortcodable;
-
                 ed.addButton('shortcodable', {
                     title: 'Insert Shortcode',
                     cmd: 'shortcodable',
@@ -27,6 +25,10 @@
 
                 // On load replace shorcode with placeholder.
                 ed.on('SetContent', function (event) {
+                    var me = tinyMCE.activeEditor.plugins.shortcodable;
+                    if (!me) {
+                        return;
+                    }
                     var newContent = me.replaceShortcodesWithPlaceholders(event.content, ed);
                     ed.execCommand('setContent', false, newContent, false);
                 });


### PR DESCRIPTION
This prevents occasional CMS-breaking errors:

> `Cannot read property 'replaceShortcodesWithPlaceholders' of undefined`

Given that placeholders don’t work at all at the moment, it doesn’t come at the cost of any functionality. I think the way the plugin is bound to TinyMCE needs updating, I just don’t have the time/knowledge 😅