### PR TITLE
Removed trailing comma from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "expose": [
             "css",
             "images",
-            "javascript",
+            "javascript"
         ]
     },
     "homepage": "https://github.com/sheadawson/silverstripe-shortcodable"


### PR DESCRIPTION
Trailing comma was present in expose section, causing a JSON parse error